### PR TITLE
Bealign optimizations and fixes

### DIFF
--- a/BioExt/misc/__init__.py
+++ b/BioExt/misc/__init__.py
@@ -320,18 +320,20 @@ def compute_cigar(reference, record, reference_name=None, new_style=False):
     return record
 
 
+def _gapless(seq):
+    return ''.join(c for c in seq if c not in _GAPS)
+
+
 def gapless(seq):
-    if not any(char in _GAPS for char in seq):
-        return seq
-    regexp = re_compile('[{0}]+'.format(''.join(_GAPS)))
+    gapless_seq = _gapless(seq)
     if isinstance(seq, str):
-        return regexp.sub('', seq)
-    elif isinstance(seq, Seq):
-        return Seq(regexp.sub('', str(seq)))
-    elif isinstance(seq, SeqRecord):
+        return gapless_seq
+    if isinstance(seq, Seq):
+        return Seq(gapless_seq)
+    if isinstance(seq, SeqRecord):
         # TODO: support features and letter_annotations here
         return SeqRecord(
-            Seq(regexp.sub('', str(seq.seq))),
+            gapless_seq,
             id=seq.id,
             name=seq.name,
             dbxrefs=copy(seq.dbxrefs),
@@ -340,8 +342,7 @@ def gapless(seq):
             annotations=copy(seq.annotations)
             # letter_annotations=seq.letter_annotations
             )
-    else:
-        raise ValueError('seq must have type SeqRecord, Seq, or str')
+    raise ValueError('seq must have type SeqRecord, Seq, or str')
 
 
 _cigar_regexp = re_compile(r'([0-9]+)([M=XID])')

--- a/BioExt/uds/__init__.py
+++ b/BioExt/uds/__init__.py
@@ -45,7 +45,7 @@ def _rc(record):
 def _align(record, aln, ref, ref_name, do_revcomp):
     records = (record, _rc(record)) if do_revcomp else (record,)
     score, ref_, record = max(
-        (aln(ref.decode('utf-8'), record) for record in records),
+        (aln(ref, record) for record in records),
         key=itemgetter(0)
         )
     record_ = compute_cigar(ref_, record, ref_name)
@@ -94,8 +94,6 @@ def _align_par(
             'reference must be one of str, Bio.Seq, Bio.SeqRecord'
             )
 
-    reference_ = refstr.encode('utf-8')
-
     def keep(score, record):
         if aln.expected(score):
             return True
@@ -118,7 +116,7 @@ def _align_par(
             n_jobs=n_jobs,
             verbose=0,
             pre_dispatch='3 * n_jobs',  # triple-buffering
-            )(delayed_(i, _align)(record, aln, reference_, reference.name, reverse_complement) for i, record in enumerate(records, start=1))
+            )(delayed_(i, _align)(record, aln, refstr, reference.name, reverse_complement) for i, record in enumerate(records, start=1))
 
         if keep(score, record)
 

--- a/tests/align.py
+++ b/tests/align.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+import nose
+
+from Bio.SeqRecord import SeqRecord
+from Bio.Seq import Seq
+
+from BioExt.align import Aligner
+from BioExt.scorematrices import BLOSUM62
+
+aln = Aligner(BLOSUM62.load())
+
+class test_Aligner():
+    def test_align_self(self):
+        """Check alignment of reference against itself"""
+        assert aln('GCTAGA', 'GCTAGA') == (4.5, 'GCTAGA', 'GCTAGA')
+
+    def test_align_self_case(self):
+        """Check case is irrelevant for self-alignment"""
+        assert aln('GCTAGA', 'GCTAGA') == aln('GCTAGA', 'GcTaGa')
+
+    def test_align_self_seq_to_str(self):
+        """Check alignment of Seq instance against seq-identical str"""
+        ref = 'GCTAGA'
+        record = Seq(ref)
+        assert aln(ref, record) == (4.5, ref, record)
+
+    def test_align_self_seqrecord_to_str(self):
+        """Check alignment of SeqRecord instance against seq-identical str"""
+        ref = 'GCTAGA'
+        record = SeqRecord(Seq(ref))
+        score, ref_aln, query_aln = aln(ref, record)
+        assert (score, ref_aln, str(query_aln.seq)) == (4.5, ref, ref)


### PR DESCRIPTION
Fixes these issues when calling an Aligner instance:

- the query had to be a SeqRecord instance cause the check
  `ref == str(query.seq)` requires a seq attribute of the query
- for codon alignment of identical sequences, the score was normalized
  to the alignment length in nucleotides instead of in codons

Optimizations:

- the check for identical ref and query is now performed after
  converting both to upper-cased strings, i.e. identity is detected more
  reliably
- degapping of ref and query avoids redundant type checks
- eliminates a superfluous encoding/decoding roundtrip between uds._align_par and uds._align