### PR TITLE
Don't generate BAM index in msa2bam if it already exists

### DIFF
--- a/scripts/bam2msa
+++ b/scripts/bam2msa
@@ -2,6 +2,7 @@
 
 import signal
 import argparse
+import os.path
 
 from Bio import SeqIO
 from BioExt.io._SamBamIO import _to_seqrecord
@@ -36,8 +37,9 @@ def main(bam_file, out_handle, start=None, end=None):
         pass
 
     try:
-        # Index bam file in order to samfile.fetch
-        pysam.index(bam_file)
+        if not os.path.exists(f"{bam_file}.bai"):
+            # Index bam file in order to samfile.fetch
+            pysam.index(bam_file)
         samfile = pysam.Samfile(bam_file, 'rb')
         length = samfile.header['SQ'][0]['LN']
         fetch_args = []


### PR DESCRIPTION
In Galaxy these are pregenerated for all BAM datasets, so always generating it is not necessary in that case.

I could also add a time check so that the index will be force-regenerated if it exists but is older than the BAM. That would probably make the change a little safer for command line usage.