### PR TITLE
bam2msa small softclipping fix 

### DIFF
--- a/BioExt/misc/__init__.py
+++ b/BioExt/misc/__init__.py
@@ -345,7 +345,7 @@ def gapless(seq):
     raise ValueError('seq must have type SeqRecord, Seq, or str')
 
 
-_cigar_regexp = re_compile(r'([0-9]+)([M=XID])')
+_cigar_regexp = re_compile(r'([0-9]+)([M=XIDSH])')
 
 
 def gapful(record, insertions=True):

--- a/BioExt/misc/__init__.py
+++ b/BioExt/misc/__init__.py
@@ -345,7 +345,7 @@ def gapless(seq):
     raise ValueError('seq must have type SeqRecord, Seq, or str')
 
 
-_cigar_regexp = re_compile(r'([0-9]+)([M=XIDSH])')
+_cigar_regexp = re_compile(r'([0-9]+)([M=XIDS])')
 
 
 def gapful(record, insertions=True):


### PR DESCRIPTION
Adding softclip and hardclip hadling to output correct reads with those kind of alignments

I was testing the "bam2msa" script, and it was really helpful, specially for the insertion ignoring functionality. But i found some problems regarding softclipped alignments as the program doesn't skip the necessary bases before writing to the sequence record.  If you look at the third row of this msa that i made using BioExt v0.21.9 you will see that it doesn't fit quite well. In particular that read had this CIGAR string "22S56M63S" :

![Before_zoom_01](https://github.com/user-attachments/assets/9e91f3df-edc9-4855-b7cf-73dfb439a293)

I simply modified the CIGAR matching regex so that it also matches "S" and "H" for softclippled or hardclippled bases. The downstream code logic seems to be able to handle this modification without major problems.  After said modification the same row in the previous alignment now fits as expected:

![After_zoom_01](https://github.com/user-attachments/assets/dae49b6f-ec95-483a-a4f5-568c7322b700)

I also found good fit in other reads that also had softclipping.  I understand that these heavily softclipped alignments may be a signal for chimeric reads or alignment errors. But that is something that can be filtered out before using bam2msa(See [samclip](https://github.com/tseemann/samclip)). A warning to the user may be good. But in case someone wants to include softclipped reads or uses the program without filtering, this would be less of a headache. 

I briefly checked for the effects on the function "gapful" and "clip"  from misc. And the code logic seems robust to this change. I'm not too familiar with testing. I just directly tested "bam2msa"

